### PR TITLE
Set mpi4py version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "h5py",
-  "mpi4py",
+  "mpi4py==4.0.3",
   "numpy",
   "scipy",
   "tools21cm",


### PR DESCRIPTION
The newest versions of mpi4py (>= 4.1.0) have troubles finding the right MPI libraries: the soname`libmpi.so.12` with a fixed version number is looked for, which is not always correct. This problem doesn't appear with version 4.0.3, which is the last one before 4.1.0.